### PR TITLE
Add browser automation skill

### DIFF
--- a/skills/browser-automation/SKILL.md
+++ b/skills/browser-automation/SKILL.md
@@ -80,6 +80,36 @@ Before moving to Phase 2, compile a **Site exploration notes** block for yoursel
 
 This catalog is the source of truth for the script you will generate.
 
+## Credential and environment variable handling
+
+When the user asks to use environment variables for credentials (e.g. HTTP Basic Auth usernames, passwords, API keys), follow these rules strictly:
+
+1. **Never read environment variable values into the conversation context.** Do not run `echo $VAR`, `printenv VAR`, or any command that would expose the secret in tool output.
+2. **Interpolate as shell variables in commands.** When constructing URLs or passing credentials in shell commands, reference them directly as `${VAR_NAME}` so the shell resolves them at runtime:
+
+   ```
+   npx agent-browser open "https://${HTTP_USERNAME}:${HTTP_PASSWORD}@example.com/protected"
+   ```
+
+3. **Use `process.env` in generated scripts.** In the Playwright script, read credentials from the environment at runtime:
+
+   ```js
+   const username = process.env.HTTP_USERNAME;
+   const password = process.env.HTTP_PASSWORD;
+   if (!username || !password) {
+     throw new Error("Missing required environment variables: HTTP_USERNAME, HTTP_PASSWORD");
+   }
+   ```
+
+4. **Document required variables.** Add a "Required environment variables" section to the script header listing every variable the script expects, without default values or examples that could leak secrets.
+5. **Include in run instructions.** When presenting the result, show how to pass variables:
+
+   ```
+   HTTP_USERNAME=<value> HTTP_PASSWORD=<value> node bin/script.mjs
+   ```
+
+   Or note that they should be exported beforehand.
+
 ## Phase 2: Script generation
 
 Translate the exploration notes into a standalone Playwright script.
@@ -103,6 +133,7 @@ The template header contains metadata placeholders that **must be filled in** so
 | `{{ORIGINAL_REQUEST}}` | The user's original instructions, quoted verbatim or closely paraphrased. Wrap to 72 characters with leading whitespace to stay inside the comment block. |
 | `{{FLOW_MODIFICATIONS}}` | Any changes the user requested after reviewing the exploration summary (added steps, removed steps, adjusted parameters). Write "None" if the user approved the flow without changes. |
 | `{{WORKFLOW_SUMMARY}}` | A numbered list of the high-level steps the script performs (e.g. "1. Navigate to booking page, 2. Select date and time, 3. Add to cart, 4. Validate summary"). One step per line, indented to align inside the comment block. |
+| `{{REQUIRED_ENV_VARS}}` | A list of environment variables the script needs at runtime (e.g. `HTTP_USERNAME`, `HTTP_PASSWORD`). Write "None" if the script does not require any. Never include actual values or examples that could leak secrets. |
 | `{{GENERATED_DATE}}` | The current date in YYYY-MM-DD format. |
 | `{{TARGET_URL}}` (header) | Same value as the `TARGET_URL` constant in the script body. |
 

--- a/skills/browser-automation/SKILL.md
+++ b/skills/browser-automation/SKILL.md
@@ -15,6 +15,8 @@ Use `agent-browser` (via `npx agent-browser`) to walk through the target site. T
 
 When presented with multiple options, ask the user for confirmation before proceeding.
 
+**IMPORTANT:** Present the summary to the user and **wait for their confirmation** before proceeding to Phase 2. The user may want to adjust the flow, correct assumptions, or add steps before any code is generated.
+
 ### 1.1 Open the page
 
 ```

--- a/skills/browser-automation/SKILL.md
+++ b/skills/browser-automation/SKILL.md
@@ -1,0 +1,196 @@
+---
+name: browser-automation
+description: Explore a website interactively with agent-browser, then generate a tested Playwright script that automates the discovered workflow. Use when users want to automate a web interaction, create a browser script, scrape a site, or fill out a form programmatically. Triggers include "automate this site", "automate fill this form", "navigate to and do", or any request involving browser workflow automation.
+---
+
+# Browser automation
+
+You help users automate browser workflows by first exploring a target site interactively, then producing a tested Playwright script that reproduces the discovered flow.
+
+The work happens in two distinct phases. Never skip Phase 1; the exploration is what makes the generated script reliable.
+
+## Phase 1: Interactive exploration
+
+Use `agent-browser` (via `npx agent-browser`) to walk through the target site. The goal is to build a **complete picture** of the page structure, selectors, data attributes, timing behavior, and edge cases before writing any code.
+
+When presented with multiple options, ask the user for confirmation before proceeding.
+
+### 1.1 Open the page
+
+```
+npx agent-browser open <url>
+```
+
+If the site blocks headless access (CDN bot detection, Akamai, Cloudflare), retry with headed mode and anti-detection flags:
+
+```
+npx agent-browser close
+npx agent-browser --headed --args "--disable-blink-features=AutomationControlled" \
+  --user-agent "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/131.0.0.0 Safari/537.36" \
+  open <url>
+```
+
+### 1.2 Discover page structure
+
+Take snapshots at every meaningful state change:
+
+```
+npx agent-browser snapshot        # full accessibility tree
+npx agent-browser snapshot -i     # interactive elements only
+npx agent-browser snapshot -c     # compact (removes empty nodes)
+```
+
+For each step of the user's desired workflow:
+
+1. **Identify interactive elements** and their refs (`@e1`, `@e2`, ...).
+2. **Record selectors**: note CSS classes, `data-*` attributes, ARIA roles, and text content. Prefer stable attributes (`data-*`, `role`, `aria-label`) over brittle ones (nth-child, generated class names).
+3. **Check for hidden state**: use `eval` to inspect attributes the snapshot does not expose (e.g. `data-availability`, `disabled`, `aria-pressed`).
+4. **Handle obstacles**: dismiss cookie banners, close modals, accept terms before proceeding.
+
+### 1.3 Interact and observe
+
+Click, fill, and navigate using refs from the snapshot:
+
+```
+npx agent-browser click @e5
+npx agent-browser fill @e3 "some text"
+npx agent-browser select @e7 "option-value"
+```
+
+After every interaction, **re-snapshot** to capture the new state. Page transitions invalidate previous refs.
+
+When a standard click times out or a button is hidden (mobile/desktop variants), fall back to JavaScript evaluation:
+
+```
+npx agent-browser eval "document.querySelector('selector').click()"
+```
+
+### 1.4 Catalog what you learned
+
+Before moving to Phase 2, compile a **Site exploration notes** block for yourself that records:
+
+- **URL and anti-bot measures** observed (headed mode needed, custom UA, etc.)
+- **Step-by-step flow** with the action taken and the resulting page state
+- **Selectors used** at each step and why they were chosen
+- **Dynamic data** (availability attributes, loaded-via-JS elements, timing-sensitive content)
+- **Edge cases** (sold-out slots, hidden buttons, dual mobile/desktop elements)
+- **Validation points** (summary panels, confirmation text, status messages)
+
+This catalog is the source of truth for the script you will generate.
+
+## Phase 2: Script generation
+
+Translate the exploration notes into a standalone Playwright script.
+
+### 2.1 Scaffold the script
+
+Use the template in [templates/playwright-script.mjs](templates/playwright-script.mjs) as a starting point. The template includes:
+
+- Anti-detection launch flags and custom user agent
+- Cookie banner dismissal
+- Structured step comments
+- Error handling with screenshot capture
+- `--headed` CLI flag for visual debugging
+
+Adapt the template to the specific workflow. Every script should:
+
+1. Accept a `--headed` flag so users can watch the browser.
+2. Log each step to the console with clear descriptions.
+3. Use resilient selectors (data attributes, ARIA roles, text content).
+4. Include explicit waits based on what the exploration revealed (not arbitrary sleeps).
+5. Validate results before proceeding to the next step.
+
+### 2.2 Selector strategy (order of preference)
+
+1. **Data attributes**: `[data-availability="available"]`, `[data-cart-step-btn]`
+2. **ARIA roles and labels**: `getByRole('button', { name: 'Increase quantity' })`
+3. **CSS classes scoped to the component**: `.sidebar__hours-btn`, `.list-cart__price-label`
+4. **Text content** (via Playwright locators): `locator('li', { hasText: 'Full Rate' })`
+5. **`page.evaluate()`** as last resort for hidden elements or React state that does not respond to synthetic events.
+
+### 2.3 Timing strategy
+
+Never use arbitrary `waitForTimeout` as the primary wait. Prefer:
+
+- `waitForSelector` for elements that appear after navigation or AJAX
+- `waitForFunction` for conditions in JavaScript state (button enabled, attribute changed)
+- `waitForTimeout` only as a small buffer after a confirmed state change
+
+When the exploration revealed that a button exists in two variants (mobile hidden, desktop visible), use `page.evaluate()` to click the enabled one rather than fighting visibility checks.
+
+### 2.4 Add validation steps
+
+After completing the main workflow, add assertions that verify the final state. Query the page for summary or confirmation elements and compare their values against the expected outcome. For example:
+
+- Read a summary panel and assert the item name, quantity, and total.
+- Verify a confirmation message appeared.
+- Check that a "proceed" button is enabled.
+
+Collect all mismatches into an array and throw a single descriptive error so the user sees every failure at once.
+
+### 2.5 Iterate until the script passes in both modes
+
+The script must pass in **both headless and headed mode** before it is considered done. Some sites behave differently depending on whether a visible browser window is present (bot detection, viewport-dependent rendering, lazy loading triggers), so testing only one mode is not sufficient.
+
+#### Step 1: Test in headed mode first
+
+Start with headed mode so you can visually confirm each step works:
+
+```
+node bin/<script-name>.mjs --headed
+```
+
+Fix any failures before moving on. Headed mode is easier to debug because you can see what the browser is doing.
+
+#### Step 2: Test in headless mode
+
+Once headed mode passes, run without the flag:
+
+```
+node bin/<script-name>.mjs
+```
+
+If headless mode fails where headed mode succeeded, the cause is almost always one of:
+
+| Headless-specific symptom | Likely cause | Fix |
+|---|---|---|
+| Access Denied / blank page | Bot detection triggers on headless | Ensure anti-detection args and custom UA are set in the script |
+| Element not visible / click intercepted | Viewport size differs in headless | Set an explicit viewport size in the browser context |
+| Timeout waiting for selector | Lazy loading needs a visible window | Add `waitForSelector` with longer timeout, or trigger scroll via `page.evaluate()` |
+| Screenshot shows different layout | Default headless viewport is smaller | Match headed viewport: `viewport: { width: 1280, height: 720 }` |
+
+#### Step 3: Confirm both pass
+
+Re-run both commands one final time after all fixes:
+
+```
+node bin/<script-name>.mjs --headed
+node bin/<script-name>.mjs
+```
+
+The script is done only when **both runs complete end-to-end with all validations passing**.
+
+#### Common issues (both modes)
+
+| Symptom | Likely cause | Fix |
+|---|---|---|
+| Timeout waiting for selector | Element loaded later than expected | Increase timeout or add a preceding wait |
+| Strict mode violation (multiple matches) | Locator is too broad | Add a more specific selector or use `.first()` / `.nth()` |
+| Element not visible | Mobile/desktop dual rendering | Use `page.evaluate()` to click |
+| Click has no effect | React/framework swallows synthetic events | Dispatch native events via `page.evaluate()` |
+| Access Denied on navigation | Bot detection | Switch to headed mode with anti-detection flags |
+
+## Presenting the result
+
+When the script passes in both headless and headed mode, provide the user with:
+
+1. **How to run it**: both commands (`node bin/<name>.mjs` for CI/headless and `node bin/<name>.mjs --headed` for visual debugging).
+2. **Test results**: confirm that the script passed in both headless and headed mode.
+3. **Step summary**: a numbered list of what the script does.
+4. **Key implementation details**: anti-detection measures, selector choices, validation logic.
+5. **Limitations**: anything that might break if the site changes (fragile selectors, time-sensitive availability).
+
+## Additional resources
+
+- For the script template, see [templates/playwright-script.mjs](templates/playwright-script.mjs)
+- For a detailed exploration reference, see [references/exploration-guide.md](references/exploration-guide.md)

--- a/skills/browser-automation/SKILL.md
+++ b/skills/browser-automation/SKILL.md
@@ -167,7 +167,48 @@ Every script should:
 4. **Text content** (via Playwright locators): `locator('li', { hasText: 'Full Rate' })`
 5. **`page.evaluate()`** as last resort for hidden elements or React state that does not respond to synthetic events.
 
-### 2.3 Timing strategy
+### 2.3 Iframe handling
+
+Many sites embed critical functionality inside iframes: payment forms (Stripe, Braintree), chat widgets, consent managers, and third-party widgets. Playwright cannot interact with iframe content using regular locators; you must use `frameLocator()` to scope into the iframe first.
+
+#### Basic pattern
+
+```js
+// Locate the iframe by its selector, then interact with elements inside it
+const paymentFrame = page.frameLocator('iframe[name="payment-form"]');
+await paymentFrame.locator('#card-number').fill('4242424242424242');
+await paymentFrame.locator('#expiry').fill('12/30');
+await paymentFrame.locator('#cvc').fill('123');
+await paymentFrame.getByRole('button', { name: 'Pay' }).click();
+```
+
+#### Key points
+
+- `frameLocator()` returns a locator-like object scoped to the iframe content
+- All standard locator methods (`.locator()`, `.getByRole()`, `.fill()`, `.click()`) work inside the frame
+- Playwright handles cross-origin iframes automatically; you do not need special permissions
+- Nested iframes require chaining: `page.frameLocator('#outer').frameLocator('#inner')`
+
+#### Common iframe scenarios
+
+| Scenario | Typical selector | Notes |
+|---|---|---|
+| Payment forms (Stripe) | `iframe[name*="stripe"]` | Multiple iframes for card number, expiry, CVC |
+| Chat widgets | `iframe[title*="chat"]` | Often appears after delay |
+| Consent managers | `iframe[src*="consent"]` | May block main page interaction |
+| Embedded maps | `iframe[src*="maps"]` | Usually read-only, rarely need interaction |
+
+#### Waiting for iframe content
+
+If the iframe loads content dynamically, wait for an element inside it before interacting:
+
+```js
+const frame = page.frameLocator('iframe#checkout');
+await frame.locator('#card-number').waitFor({ state: 'visible', timeout: 10000 });
+await frame.locator('#card-number').fill(cardNumber);
+```
+
+### 2.4 Timing strategy
 
 Never use arbitrary `waitForTimeout` as the primary wait. Prefer:
 

--- a/skills/browser-automation/SKILL.md
+++ b/skills/browser-automation/SKILL.md
@@ -85,10 +85,14 @@ This catalog is the source of truth for the script you will generate.
 When the user asks to use environment variables for credentials (e.g. HTTP Basic Auth usernames, passwords, API keys), follow these rules strictly:
 
 1. **Never read environment variable values into the conversation context.** Do not run `echo $VAR`, `printenv VAR`, or any command that would expose the secret in tool output.
-2. **Interpolate as shell variables in commands.** When constructing URLs or passing credentials in shell commands, reference them directly as `${VAR_NAME}` so the shell resolves them at runtime:
+2. **Interpolate as shell variables in commands.** When passing credentials in shell commands, reference them directly as `${VAR_NAME}` so the shell resolves them at runtime:
 
    ```
-   npx agent-browser open "https://${HTTP_USERNAME}:${HTTP_PASSWORD}@example.com/protected"
+   # Set credentials before navigation
+   npx agent-browser set credentials ${HTTP_USERNAME} ${HTTP_PASSWORD}
+
+   # Navigate to protected resource
+   npx agent-browser open "https://example.com/protected"
    ```
 
 3. **Use `process.env` in generated scripts.** In the Playwright script, read credentials from the environment at runtime:

--- a/skills/browser-automation/SKILL.md
+++ b/skills/browser-automation/SKILL.md
@@ -214,9 +214,9 @@ If headless mode fails where headed mode succeeded, the cause is almost always o
 | Headless-specific symptom | Likely cause | Fix |
 |---|---|---|
 | Access Denied / blank page | Bot detection triggers on headless | Ensure anti-detection args and custom UA are set in the script |
-| Element not visible / click intercepted | Viewport size differs in headless | Set an explicit viewport size in the browser context |
+| Element not visible / click intercepted | Viewport too small for element | Increase viewport dimensions or scroll element into view |
 | Timeout waiting for selector | Lazy loading needs a visible window | Add `waitForSelector` with longer timeout, or trigger scroll via `page.evaluate()` |
-| Screenshot shows different layout | Default headless viewport is smaller | Match headed viewport: `viewport: { width: 1280, height: 720 }` |
+| Screenshot shows different layout | Site has responsive breakpoints | Adjust viewport to match target device width |
 
 #### Step 3: Confirm both pass
 

--- a/skills/browser-automation/SKILL.md
+++ b/skills/browser-automation/SKILL.md
@@ -94,7 +94,23 @@ Use the template in [templates/playwright-script.mjs](templates/playwright-scrip
 - Error handling with screenshot capture
 - `--headed` CLI flag for visual debugging
 
-Adapt the template to the specific workflow. Every script should:
+#### Fill in the script header metadata
+
+The template header contains metadata placeholders that **must be filled in** so the script is self-documenting. When someone opens the file later, the header should give them full context about what it does and why.
+
+| Placeholder | What to write |
+|---|---|
+| `{{ORIGINAL_REQUEST}}` | The user's original instructions, quoted verbatim or closely paraphrased. Wrap to 72 characters with leading whitespace to stay inside the comment block. |
+| `{{FLOW_MODIFICATIONS}}` | Any changes the user requested after reviewing the exploration summary (added steps, removed steps, adjusted parameters). Write "None" if the user approved the flow without changes. |
+| `{{WORKFLOW_SUMMARY}}` | A numbered list of the high-level steps the script performs (e.g. "1. Navigate to booking page, 2. Select date and time, 3. Add to cart, 4. Validate summary"). One step per line, indented to align inside the comment block. |
+| `{{GENERATED_DATE}}` | The current date in YYYY-MM-DD format. |
+| `{{TARGET_URL}}` (header) | Same value as the `TARGET_URL` constant in the script body. |
+
+This metadata block serves as a quick reference when revisiting the script. Keep each field concise but complete enough to understand the intent without reading the code.
+
+#### Adapt the template to the workflow
+
+Every script should:
 
 1. Accept a `--headed` flag so users can watch the browser.
 2. Log each step to the console with clear descriptions.

--- a/skills/browser-automation/SKILL.md
+++ b/skills/browser-automation/SKILL.md
@@ -128,20 +128,26 @@ Use the template in [templates/playwright-script.mjs](templates/playwright-scrip
 - Error handling with screenshot capture
 - `--headed` CLI flag for visual debugging
 
-#### Fill in the script header metadata
+#### Fill in template placeholders
 
-The template header contains metadata placeholders that **must be filled in** so the script is self-documenting. When someone opens the file later, the header should give them full context about what it does and why.
+The template contains placeholders that **must be filled in** so the script is self-documenting. When someone opens the file later, the header should give them full context about what it does and why.
 
 | Placeholder | What to write |
 |---|---|
+| `{{SCRIPT_DESCRIPTION}}` | A one-line summary of what the script does (e.g., "Books a time slot on example.com and validates the cart"). Keep it under 80 characters. |
+| `{{SCRIPT_NAME}}` | The filename without the `.mjs` extension. Must match the actual file you create (e.g., `book-timeslot` if the file is `bin/book-timeslot.mjs`). |
 | `{{ORIGINAL_REQUEST}}` | The user's original instructions, quoted verbatim or closely paraphrased. Wrap to 72 characters with leading whitespace to stay inside the comment block. |
 | `{{FLOW_MODIFICATIONS}}` | Any changes the user requested after reviewing the exploration summary (added steps, removed steps, adjusted parameters). Write "None" if the user approved the flow without changes. |
 | `{{WORKFLOW_SUMMARY}}` | A numbered list of the high-level steps the script performs (e.g. "1. Navigate to booking page, 2. Select date and time, 3. Add to cart, 4. Validate summary"). One step per line, indented to align inside the comment block. |
 | `{{REQUIRED_ENV_VARS}}` | A list of environment variables the script needs at runtime (e.g. `HTTP_USERNAME`, `HTTP_PASSWORD`). Write "None" if the script does not require any. Never include actual values or examples that could leak secrets. |
 | `{{GENERATED_DATE}}` | The current date in YYYY-MM-DD format. |
-| `{{TARGET_URL}}` (header) | Same value as the `TARGET_URL` constant in the script body. |
+| `{{TARGET_URL}}` | The target URL for the automation. This value appears in both the header comment and the `TARGET_URL` constant in the script body; use the same value for both. |
 
 This metadata block serves as a quick reference when revisiting the script. Keep each field concise but complete enough to understand the intent without reading the code.
+
+**Step comments:** The template includes numbered step sections with placeholder comments (e.g., `Step 2: {{STEP_2_DESCRIPTION}}`). Replace each placeholder with a brief description of that step's action (e.g., "Select date from calendar"). Add or remove step sections as needed to match the workflow discovered in Phase 1.
+
+**Validation checkpoint:** Before testing, search the script for `{{` to confirm no unfilled placeholders remain.
 
 #### Adapt the template to the workflow
 

--- a/skills/browser-automation/references/exploration-guide.md
+++ b/skills/browser-automation/references/exploration-guide.md
@@ -19,6 +19,7 @@ Detailed reference for the interactive exploration phase using `agent-browser`.
 | Close browser | `npx agent-browser close` |
 | Find element and act | `npx agent-browser find text "Submit" click` |
 | Get element attribute | `npx agent-browser get attr data-id @e1` |
+| Set HTTP credentials | `npx agent-browser set credentials <user> <pass>` |
 
 ## Handling credentials during exploration
 
@@ -26,10 +27,14 @@ When the target site requires authentication (HTTP Basic Auth, login forms, API 
 
 ### HTTP Basic Auth
 
-Embed credentials in the URL using shell variable interpolation:
+Set credentials before navigating to the protected resource:
 
 ```
-npx agent-browser open "https://${HTTP_USERNAME}:${HTTP_PASSWORD}@example.com/protected"
+# Set credentials (shell resolves variables at runtime)
+npx agent-browser set credentials ${HTTP_USERNAME} ${HTTP_PASSWORD}
+
+# Navigate to protected resource
+npx agent-browser open "https://example.com/protected"
 ```
 
 ### Login forms

--- a/skills/browser-automation/references/exploration-guide.md
+++ b/skills/browser-automation/references/exploration-guide.md
@@ -1,0 +1,179 @@
+# Exploration guide
+
+Detailed reference for the interactive exploration phase using `agent-browser`.
+
+## Quick command reference
+
+| Action | Command |
+|---|---|
+| Open a URL | `npx agent-browser open <url>` |
+| Full page snapshot | `npx agent-browser snapshot` |
+| Interactive elements only | `npx agent-browser snapshot -i` |
+| Compact snapshot | `npx agent-browser snapshot -c` |
+| Scoped to a CSS selector | `npx agent-browser snapshot -s "dialog"` |
+| Click by ref | `npx agent-browser click @e5` |
+| Fill text by ref | `npx agent-browser fill @e3 "text"` |
+| Run JavaScript | `npx agent-browser eval "<js>"` |
+| Wait for time or selector | `npx agent-browser wait 2000` |
+| Take a screenshot | `npx agent-browser screenshot` |
+| Close browser | `npx agent-browser close` |
+| Find element and act | `npx agent-browser find text "Submit" click` |
+| Get element attribute | `npx agent-browser get attr data-id @e1` |
+
+## Dealing with bot protection
+
+Many production sites use CDN-level bot detection (Akamai, Cloudflare, PerimeterX). Symptoms include:
+
+- "Access Denied" page immediately on load
+- CAPTCHA challenges
+- Empty or minimal page content
+
+### Escalation strategy
+
+Try each approach in order, stopping when the page loads successfully:
+
+1. **Default headless**: `npx agent-browser open <url>`
+2. **Headed mode**: close the session first, then relaunch with `--headed`
+3. **Headed + anti-detection**: add `--args "--disable-blink-features=AutomationControlled"`
+4. **Custom user agent**: add `--user-agent "Mozilla/5.0 ..."`
+5. **Combined**: all flags together
+
+Always close the existing session before changing launch flags:
+
+```
+npx agent-browser close
+npx agent-browser --headed \
+  --args "--disable-blink-features=AutomationControlled" \
+  --user-agent "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/131.0.0.0 Safari/537.36" \
+  open <url>
+```
+
+## Snapshot reading strategy
+
+Snapshots can be large. Use these techniques to focus:
+
+- **Start with `-i`** to see only interactive elements. This gives you the action points.
+- **Use `-c`** (compact) to remove empty structural nodes when reading the full tree.
+- **Scope with `-s`** when you know the relevant container: `snapshot -s "dialog"` or `snapshot -s "[class*=modal]"`.
+- **Limit depth with `-d`**: `snapshot -d 3` for a high-level overview.
+
+## Inspecting hidden state with eval
+
+Snapshots show the accessibility tree but miss many attributes. Use `eval` to inspect:
+
+### Check all buttons matching a pattern
+
+```
+npx agent-browser eval "
+  const btns = document.querySelectorAll('.time-btn');
+  JSON.stringify([...btns].map(b => ({
+    text: b.textContent.trim(),
+    available: b.getAttribute('data-availability'),
+    disabled: b.disabled
+  })));
+"
+```
+
+### Find enabled instance among duplicates
+
+Some sites render mobile and desktop variants of the same button. Only one is visible at any viewport width:
+
+```
+npx agent-browser eval "
+  const btns = document.querySelectorAll('button');
+  const target = [...btns].find(b =>
+    b.textContent.trim() === 'Submit' && !b.disabled
+  );
+  JSON.stringify({
+    found: !!target,
+    visible: target?.offsetParent !== null,
+    class: target?.className
+  });
+"
+```
+
+### Read a summary or confirmation panel
+
+```
+npx agent-browser eval "
+  const el = document.querySelector('.order-summary');
+  if (!el) 'not found';
+  else JSON.stringify({
+    items: [...el.querySelectorAll('.line-item')].map(li => li.textContent.trim()),
+    total: el.querySelector('.total')?.textContent.trim()
+  });
+"
+```
+
+## Common page patterns
+
+### Cookie consent banners
+
+Most EU sites show a cookie banner on first visit. Common button names:
+
+- "Accept cookies", "Accept all", "Accepter les cookies"
+- "Allow all cookies", "I agree", "OK"
+
+Dismiss early so it does not block clicks on underlying elements.
+
+### Modals and overlays
+
+When a modal opens, previous page refs become stale. Always re-snapshot after a modal appears. Modals often render inside a `dialog` element or a `div` with `role="dialog"`.
+
+### Calendars and date pickers
+
+Calendar grids typically use `role="gridcell"` with `aria-label` containing the full date string (e.g. "February 8, 2026"). Construct the expected label in code and match it.
+
+If the desired date is not in the current month view, click "Next month" or "Previous month" and re-check.
+
+### Quantity selectors (stepper controls)
+
+E-commerce and ticketing sites use +/- buttons around a quantity display. The display is often a `[role="status"]` element. Find the containing row by text content and then locate the "Increase quantity" or "Decrease quantity" button within it.
+
+### Dynamic availability
+
+Slot or product availability is often stored in `data-*` attributes (e.g. `data-availability="available"`) rather than visible text. Always check these attributes via `eval` rather than relying solely on the snapshot.
+
+## Recording exploration notes
+
+After exploring the site, write a structured summary before generating the script. Include:
+
+```
+## Site exploration notes
+
+**URL**: https://example.com/page
+**Bot protection**: Headed mode required with custom UA
+**Cookie banner**: "Accept all cookies" button
+
+### Workflow steps
+
+1. Click "Buy now" button (selector: `main button:has-text("Buy now")`)
+   - Opens a modal dialog
+   - Calendar grid appears with `[role="gridcell"]` cells
+
+2. Select date: click gridcell with `aria-label="March 15, 2026"`
+   - Time slots load via AJAX, wait for `.time-slot-btn`
+   - Availability in `data-availability` attribute
+
+3. Select first available time slot
+   - Iterate `.time-slot-btn` elements
+   - Click first with `data-availability="available"`
+
+4. Confirm selection
+   - "Set" button exists in two variants (mobile hidden, desktop visible)
+   - Use `page.evaluate()` to click the enabled one
+
+5. Pick ticket type
+   - Row with text "Standard" contains +/- buttons
+   - Click "Increase quantity" within that row
+
+6. Validate summary
+   - `.order-summary` panel shows item, quantity, total
+   - `.summary-total` contains "€25"
+
+### Edge cases
+- Morning slots often sold out; script must iterate to find available ones
+- "Set" button stays disabled until a valid time is selected
+```
+
+This structured summary is the blueprint for Phase 2.

--- a/skills/browser-automation/references/exploration-guide.md
+++ b/skills/browser-automation/references/exploration-guide.md
@@ -166,6 +166,73 @@ E-commerce and ticketing sites use +/- buttons around a quantity display. The di
 
 Slot or product availability is often stored in `data-*` attributes (e.g. `data-availability="available"`) rather than visible text. Always check these attributes via `eval` rather than relying solely on the snapshot.
 
+### Iframes
+
+Many sites embed critical functionality inside iframes: payment forms (Stripe, Braintree), chat widgets (Intercom, Zendesk), third-party consent managers, and embedded content (maps, videos). Recognizing and documenting iframes during exploration is essential because interacting with iframe content requires special handling in the generated script.
+
+**Signs that an element is inside an iframe:**
+
+- The snapshot shows an `iframe` element but the content you expect is missing
+- Clicking a button opens a modal that does not appear in subsequent snapshots
+- The target element has a different origin visible in browser DevTools
+
+**Identifying iframes:**
+
+List all iframes on the page and their sources:
+
+```
+npx agent-browser eval "
+  const frames = document.querySelectorAll('iframe');
+  JSON.stringify([...frames].map(f => ({
+    id: f.id,
+    name: f.name,
+    src: f.src,
+    visible: f.offsetParent !== null
+  })));
+"
+```
+
+**Inspecting same-origin iframe content:**
+
+For iframes from the same origin, you can access their content via `eval`:
+
+```
+npx agent-browser eval "
+  const frame = document.querySelector('iframe#booking-widget');
+  const doc = frame?.contentDocument;
+  if (!doc) 'cross-origin or not loaded';
+  else JSON.stringify({
+    buttons: [...doc.querySelectorAll('button')].map(b => b.textContent.trim()),
+    inputs: [...doc.querySelectorAll('input')].map(i => i.name || i.id)
+  });
+"
+```
+
+**Cross-origin iframes:**
+
+Cross-origin iframes (e.g., `stripe.com` iframe on your site) cannot be inspected via `eval` due to browser security. During exploration, note:
+
+- The iframe selector (id, name, or CSS selector)
+- What action triggers the iframe to appear
+- What elements you expect inside based on the site's documentation or visual inspection
+
+The generated script will use Playwright's `frameLocator()` which can interact with cross-origin iframes.
+
+**Recording iframe details in exploration notes:**
+
+When you encounter an iframe, document:
+
+```
+### Iframe: Payment form
+- Selector: `iframe[name="stripe-frame"]`
+- Origin: cross-origin (stripe.com)
+- Appears after: clicking "Proceed to payment"
+- Contains: card number, expiry, CVC fields
+- Submit button: inside iframe, text "Pay now"
+```
+
+This information is critical for Phase 2, where you will use `page.frameLocator()` to interact with iframe content.
+
 ## Recording exploration notes
 
 After exploring the site, write a structured summary before generating the script. Include:

--- a/skills/browser-automation/references/exploration-guide.md
+++ b/skills/browser-automation/references/exploration-guide.md
@@ -20,6 +20,33 @@ Detailed reference for the interactive exploration phase using `agent-browser`.
 | Find element and act | `npx agent-browser find text "Submit" click` |
 | Get element attribute | `npx agent-browser get attr data-id @e1` |
 
+## Handling credentials during exploration
+
+When the target site requires authentication (HTTP Basic Auth, login forms, API keys), use environment variables and **never read their values into the conversation**.
+
+### HTTP Basic Auth
+
+Embed credentials in the URL using shell variable interpolation:
+
+```
+npx agent-browser open "https://${HTTP_USERNAME}:${HTTP_PASSWORD}@example.com/protected"
+```
+
+### Login forms
+
+Fill fields using shell variables so values are resolved at runtime and never appear in tool output:
+
+```
+npx agent-browser fill @e3 "${LOGIN_EMAIL}"
+npx agent-browser fill @e5 "${LOGIN_PASSWORD}"
+```
+
+### Key rules
+
+- **Do not** run `echo`, `printenv`, or any command that prints secret values.
+- **Do not** hardcode credentials in commands or scripts. Always use `${VAR_NAME}` in shell commands and `process.env.VAR_NAME` in JavaScript.
+- If a variable is not set, commands will fail with an empty value. Instruct the user to export the required variables before starting the exploration session.
+
 ## Dealing with bot protection
 
 Many production sites use CDN-level bot detection (Akamai, Cloudflare, PerimeterX). Symptoms include:

--- a/skills/browser-automation/templates/playwright-script.mjs
+++ b/skills/browser-automation/templates/playwright-script.mjs
@@ -16,12 +16,29 @@
  * Workflow summary:
  *   {{WORKFLOW_SUMMARY}}
  *
+ * Required environment variables:
+ *   {{REQUIRED_ENV_VARS}}
+ *
  * Generated: {{GENERATED_DATE}}
  * Target: {{TARGET_URL}}
  * ---
  */
 
 import { chromium } from "playwright";
+
+// ---------------------------------------------------------------------------
+// Environment variables
+// ---------------------------------------------------------------------------
+
+// When the workflow requires credentials or secrets, read them from the
+// environment at runtime. Never hardcode sensitive values.
+//
+// Example:
+//   const username = process.env.HTTP_USERNAME;
+//   const password = process.env.HTTP_PASSWORD;
+//   if (!username || !password) {
+//     throw new Error("Missing required env vars: HTTP_USERNAME, HTTP_PASSWORD");
+//   }
 
 const TARGET_URL = "{{TARGET_URL}}";
 

--- a/skills/browser-automation/templates/playwright-script.mjs
+++ b/skills/browser-automation/templates/playwright-script.mjs
@@ -65,6 +65,8 @@ const context = await browser.newContext({
   userAgent:
     "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) " +
     "AppleWebKit/537.36 (KHTML, like Gecko) Chrome/131.0.0.0 Safari/537.36",
+  // Explicit viewport prevents headed/headless rendering differences
+  viewport: { width: 1280, height: 720 },
 });
 
 const page = await context.newPage();

--- a/skills/browser-automation/templates/playwright-script.mjs
+++ b/skills/browser-automation/templates/playwright-script.mjs
@@ -5,6 +5,20 @@
  *   node bin/{{SCRIPT_NAME}}.mjs [--headed]
  *
  * Requires: playwright (npm install playwright)
+ *
+ * ---
+ * Original request:
+ *   {{ORIGINAL_REQUEST}}
+ *
+ * Flow modifications:
+ *   {{FLOW_MODIFICATIONS}}
+ *
+ * Workflow summary:
+ *   {{WORKFLOW_SUMMARY}}
+ *
+ * Generated: {{GENERATED_DATE}}
+ * Target: {{TARGET_URL}}
+ * ---
  */
 
 import { chromium } from "playwright";

--- a/skills/browser-automation/templates/playwright-script.mjs
+++ b/skills/browser-automation/templates/playwright-script.mjs
@@ -1,0 +1,113 @@
+/**
+ * {{SCRIPT_DESCRIPTION}}
+ *
+ * Usage:
+ *   node bin/{{SCRIPT_NAME}}.mjs [--headed]
+ *
+ * Requires: playwright (npm install playwright)
+ */
+
+import { chromium } from "playwright";
+
+const TARGET_URL = "{{TARGET_URL}}";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+// Add workflow-specific helpers here (date formatting, price parsing, etc.)
+
+// ---------------------------------------------------------------------------
+// Main
+// ---------------------------------------------------------------------------
+
+const headed = process.argv.includes("--headed");
+
+const browser = await chromium.launch({
+  headless: !headed,
+  // Disable automation detection flags that many sites check
+  args: ["--disable-blink-features=AutomationControlled"],
+});
+
+const context = await browser.newContext({
+  // Use a realistic user agent to avoid bot detection
+  userAgent:
+    "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) " +
+    "AppleWebKit/537.36 (KHTML, like Gecko) Chrome/131.0.0.0 Safari/537.36",
+});
+
+const page = await context.newPage();
+
+try {
+  // ------------------------------------------------------------------
+  // Step 1: Navigate to the target page
+  // ------------------------------------------------------------------
+  console.log("Opening page...");
+  await page.goto(TARGET_URL, { waitUntil: "domcontentloaded" });
+
+  // Dismiss cookie banner if present.
+  // Adapt the button name to match the target site.
+  const cookieBtn = page.getByRole("button", { name: "Accept cookies" });
+  if (await cookieBtn.isVisible({ timeout: 3000 }).catch(() => false)) {
+    console.log("Accepting cookies...");
+    await cookieBtn.click();
+    await page.waitForTimeout(500);
+  }
+
+  // ------------------------------------------------------------------
+  // Step 2: {{STEP_2_DESCRIPTION}}
+  // ------------------------------------------------------------------
+  // Replace this section with the first real interaction discovered
+  // during the exploration phase.  Example patterns:
+  //
+  //   await page.locator('[data-action="open"]').click();
+  //   await page.waitForSelector('.modal-content', { timeout: 10000 });
+  //
+  //   await page.getByRole('button', { name: 'Submit' }).click();
+  //
+  //   await page.locator('li', { hasText: 'Option A' }).click();
+
+  // ------------------------------------------------------------------
+  // Step N: Validate the result
+  // ------------------------------------------------------------------
+  // After completing the workflow, read confirmation or summary elements
+  // and assert their values match expectations.
+  //
+  // const summary = await page.evaluate(() => {
+  //   return {
+  //     item: document.querySelector('.summary-item')?.textContent.trim(),
+  //     total: document.querySelector('.summary-total')?.textContent.trim(),
+  //   };
+  // });
+  //
+  // const errors = [];
+  // if (!summary.item?.includes("Expected item")) {
+  //   errors.push(`Item: expected "Expected item", got "${summary.item}"`);
+  // }
+  // if (errors.length > 0) {
+  //   throw new Error("Validation failed:\n  - " + errors.join("\n  - "));
+  // }
+  //
+  // console.log("All validations passed.");
+
+  // ------------------------------------------------------------------
+  // Done
+  // ------------------------------------------------------------------
+  console.log("\nWorkflow complete.");
+
+  if (headed) {
+    console.log("Browser will stay open for 30 seconds...");
+    await page.waitForTimeout(30000);
+  }
+} catch (err) {
+  console.error("\nError:", err.message);
+
+  // Capture a screenshot so the user can see what went wrong
+  const screenshotPath = "error-screenshot.png";
+  await page.screenshot({ path: screenshotPath, fullPage: true });
+  console.error(`Screenshot saved to ${screenshotPath}`);
+
+  process.exitCode = 1;
+} finally {
+  await browser.close();
+}

--- a/skills/browser-automation/templates/playwright-script.mjs
+++ b/skills/browser-automation/templates/playwright-script.mjs
@@ -49,6 +49,22 @@ const TARGET_URL = "{{TARGET_URL}}";
 // Add workflow-specific helpers here (date formatting, price parsing, etc.)
 
 // ---------------------------------------------------------------------------
+// Iframe handling
+// ---------------------------------------------------------------------------
+
+// When interacting with elements inside an iframe (payment forms, chat widgets,
+// consent managers), use frameLocator() to scope into the iframe first:
+//
+//   const paymentFrame = page.frameLocator('iframe[name="payment-form"]');
+//   await paymentFrame.locator('#card-number').fill(cardNumber);
+//   await paymentFrame.locator('#expiry').fill(expiry);
+//   await paymentFrame.locator('#cvc').fill(cvc);
+//   await paymentFrame.getByRole('button', { name: 'Pay' }).click();
+//
+// For nested iframes, chain frameLocator calls:
+//   page.frameLocator('#outer').frameLocator('#inner').locator('button')
+
+// ---------------------------------------------------------------------------
 // Main
 // ---------------------------------------------------------------------------
 


### PR DESCRIPTION
Introduce a skill that leverages agent-browser CLI to interactively explore websites and then generate tested Playwright scripts from the discovered workflows.

The skill is structured in two phases: first, an interactive exploration that catalogs page structure, selectors, timing, and edge cases; second, script generation using those findings to produce reliable automation code.

This is intended to help developers quickly scaffold end-to-end browser automation scripts (for CI or local use) without having to manually inspect selectors and write Playwright boilerplate from scratch. It complements, rather than replaces, QA-authored test suites.

Includes:
- SKILL.md with full two-phase workflow instructions
- Exploration guide reference with command cheatsheet, bot-protection escalation, and common page patterns
- Playwright script template with anti-detection setup, cookie dismissal, structured steps, and error handling